### PR TITLE
Using the scheduler as a Windows service

### DIFF
--- a/sources/29-web2py-english/13.markmin
+++ b/sources/29-web2py-english/13.markmin
@@ -838,6 +838,32 @@ python web2py.py -W start
 python web2py.py -W stop
 ``:code
 
+#### Start the scheduler as a Windows service
+``Windows scheduler service``:inxx
+
+Running the scheduler as a Windows service makes a lot of sense.
+The easiest approach is to download nssm (from htp://www.nssm.cc). nssm is an open source scheduling helper.
+It wraps around an executable command to turn it into a service.
+The command to start the scheduler is ''pythonw.exe -K <appname>''
+We use nssm to wrap around this, becoming a service.
+Before doing this, you need to choose a name for your service.
+There are strong advantages to creating a specific service for each app which needs a scheduler.
+Therefore, your naming convention for services may be web2py_scheduler_app1
+
+After extracting the zip file, open a Windows command prompt in the folder containing the version for your architecture, and type
+``
+nssm install web2py_scheduler_app1``:code
+
+This shows a dialog asking you to enter Application and Options.
+Application is the pythonw.exe executable from your Python installation.
+Options is
+``-K app1``:code 
+where app1 is the name of your application.
+
+It is possible to invoke the scheduler with multiple applications. However, in this mode, web2py detaches each application's scheduler into a subprocess.
+Therefore, the process started by the service will not die if one of the scheduler instances runs into problems; rather, that child process would die. 
+We then can't take advantage of automatic restarting of services in case of failure. Using one app per service avoids this weakness. 
+
 ### Securing sessions and **admin**
 ``security``:inxx ``admin``:inxx
 


### PR DESCRIPTION
Using tips from niphlod, this text shows how to easily install web2py schedulers as a windows service.
