### PR TITLE
Chapter 3: auth.wiki model customization

### DIFF
--- a/sources/29-web2py-english/03.markmin
+++ b/sources/29-web2py-english/03.markmin
@@ -1470,7 +1470,7 @@ Note that you still have to call auth.wiki() in the controller or view in order 
 ------
 
 
-Also, by setting resolve to ``True`` in the method call, the wiki tables will be now accesible trough the app's default db interface at ``<app>/appadmin`` for managing wiki records.
+Also, by setting resolve to ``False`` in the method call, the wiki tables will be now accesible trough the app's default db interface at ``<app>/appadmin`` for managing wiki records.
 
 
 Another customization possible is adding extra fields to the standard wiki tables (in the same way as with the ``auth_user`` table, as described in Chapter 9). Here is how:
@@ -1480,7 +1480,7 @@ Another customization possible is adding extra fields to the standard wiki table
 auth.settings.extra_fields["wiki_page"] = [Field("ablob", "blob"),]
 ``:code
 
-The line above adds a blob field to the wiki_page table. There is no need to call ``auth.wiki(resolve=False)``:code for this option, unless you need access to the wiki model for other customizations.
+The line above adds a ``blob`` field to the ``wiki_page`` table. There is no need to call ``auth.wiki(resolve=False)``:code for this option, unless you need access to the wiki model for other customizations.
 
 
 #### Components


### PR DESCRIPTION
I think that the book could use a dedicated chapter on auth.wiki and the markmin syntax and helper, leaving a succint intro in chapter 3.
