### PR TITLE
An alternative download link for Facebook's GraphAPI

### DIFF
--- a/sources/29-web2py-english/09.markmin
+++ b/sources/29-web2py-english/09.markmin
@@ -543,7 +543,7 @@ auth.settings.login_form=OAuthAccount(YOUR_CLIENT_ID,YOUR_CLIENT_SECRET)
 
 Things get a little more complex if you want to use Facebook OAuth2.0 to login into a specific Facebook app to access its API, instead of your own app. Here is an example for accessing the Facebook Graph API.
 
-First of all you must install the [[Facebook Python SDK https://github.com/facebook/python-sdk]].
+First of all you must install the [[Facebook Python SDK https://github.com/pythonforfacebook/facebook-sdk/]].
 
 Second, you need the following code in your model:
 


### PR DESCRIPTION
Replaced the abandoned facebook module by a forked project. The original link is broken
Perhaps the book should note that the module is no longer maintained by Facebook
