### PR TITLE
Make www-data dir consistent with the scripts

### DIFF
--- a/sources/29-web2py-english/13.markmin
+++ b/sources/29-web2py-english/13.markmin
@@ -149,12 +149,12 @@ The Apache logs are in:
 
 Download and unzip web2py source on the machine where you installed the web server above.
 
-Install web2py under ``/users/www-data/``, for example, and give ownership to user www-data and group www-data. These steps can be performed with the following shell commands:
+Install web2py under ``/home/www-data/``, for example, and give ownership to user www-data and group www-data. These steps can be performed with the following shell commands:
 ``
-cd /users/www-data/
+cd /home/www-data/
 sudo wget http://web2py.com/examples/static/web2py_src.zip
 sudo unzip web2py_src.zip
-sudo chown -R www-data:www-data /user/www-data/web2py
+sudo chown -R www-data:www-data /home/www-data/web2py
 ``:code
 
 To set up web2py with mod_wsgi, create a new Apache configuration file:
@@ -168,9 +168,9 @@ and include the following code:
   ServerName web2py.example.com
   WSGIDaemonProcess web2py user=www-data group=www-data display-name=%{GROUP}
   WSGIProcessGroup web2py
-  WSGIScriptAlias / /users/www-data/web2py/wsgihandler.py
+  WSGIScriptAlias / /home/www-data/web2py/wsgihandler.py
 
-  <Directory /users/www-data/web2py>
+  <Directory /home/www-data/web2py>
     AllowOverride None
     Order Allow,Deny
     Deny from all


### PR DESCRIPTION
`/home/www-data` is the directory used in Linux installation scripts like setup-web2py-ubuntu.sh. Let's make it consistent.
