### PR TITLE
Correction to minor typo (missing ' ' )

### DIFF
--- a/sources/29-web2py-english/09.markmin
+++ b/sources/29-web2py-english/09.markmin
@@ -903,7 +903,7 @@ If the visitor is not logged in, then the permission cannot be checked; the visi
 
 Occasionally, it is necessary to combine requirements. This can be done via a generic ``requires`` decorator which takes a single argument, a true or false condition. For example, to give access to agents, but only on Tuesday:
 ``
-@auth.requires(auth.has_membership(group_id=agents) \
+@auth.requires(auth.has_membership(group_id='agents' \
                and request.now.weekday()==1)
 def function_seven():
     return 'Hello agent, it must be Tuesday!'


### PR DESCRIPTION
I noticed today that there seem to be some missing quotes around a literal string in an example.
