### PR TITLE
Bug fix in URL simplewiki rss code.

### DIFF
--- a/sources/29-web2py-english/03.markmin
+++ b/sources/29-web2py-english/03.markmin
@@ -1147,7 +1147,7 @@ def news():
        created_on = request.now,
        items = [
           dict(title = row.title,
-               link = URL('show', args=row.id),
+               link = URL('show', args=row.id, extension=False),
                description = MARKMIN(row.body).xml(),
                created_on = row.created_on
                ) for row in pages])


### PR DESCRIPTION
If not extension argument is passed to the URL helper, by default the extension is the same as the current request, in this case the current request have the .rss extension, so URL produces a link to the "show.rss" action witch is invalid.
