### PR TITLE
Added URL arguments to get it working

### DIFF
--- a/sources/29-web2py-english/03.markmin
+++ b/sources/29-web2py-english/03.markmin
@@ -1147,7 +1147,7 @@ def news():
        created_on = request.now,
        items = [
           dict(title = row.title,
-               link = URL('show', args=row.id),
+               link = link = URL('show', args=show.id, scheme=True, host=True, extension=False),
                description = MARKMIN(row.body).xml(),
                created_on = row.created_on
                ) for row in pages])


### PR DESCRIPTION
In order to get the link working in the RSS feed, the link should also add scheme and host, and ignore the .rss extension that's added by the response.generic_patterns['.rss']
