### PR TITLE
Correction for the function name in the example of Chapter 4

### DIFF
--- a/sources/29-web2py-english/04.markmin
+++ b/sources/29-web2py-english/04.markmin
@@ -912,7 +912,7 @@ results in the following ``request`` object:
 **variable** | **value**
 ``request.application`` | ``examples``
 ``request.controller`` | ``default``
-``request.function`` | ``index``
+``request.function`` | ``status``
 ``request.extension`` | ``html``
 ``request.view`` | ``status``
 ``request.folder`` | ``applications/examples/``


### PR DESCRIPTION
Function name in /examples/default/status/x/y/z?p=1&q=2 request is "status", not "index".
