### PR TITLE
Fixed the wiki env example (overview)

### DIFF
--- a/sources/29-web2py-english/03.markmin
+++ b/sources/29-web2py-english/03.markmin
@@ -1335,7 +1335,7 @@ You can use the ``env`` parameter of ``auth.wiki`` to expose functions to your w
 For example:
 
 ``
-auth.wiki(env=dict(join=lambda a,b,c:"%s-%s-%s" % (a,b,c)))
+auth.wiki(env=dict(join=lambda a:"-".join(a.split(","))))
 ``
 
 allows you to use the markup syntax:
@@ -1345,7 +1345,8 @@ allows you to use the markup syntax:
 ``
 
 
-This calls the join function passed as extra with parameters ``a,b,c=1,2,3`` and will be rendered as ``1-2-3``.
+This calls the join function passed to env with parameters ``a,b,c=1,2,3`` and will be rendered as ``1-2-3``.
+
 
 #### Oembed protocol
 


### PR DESCRIPTION
I have changed the lambda example using join instead of string interpolation and removed the reference to extra (because wiki also receives extra as argument but it is used for custom markup render)
