### PR TITLE
Fixed documentation of SQLFORM buttons argument, added simple example

### DIFF
--- a/sources/29-web2py-english/07.markmin
+++ b/sources/29-web2py-english/07.markmin
@@ -336,6 +336,7 @@ form.add_button('Back', URL('other_page'))
 ``:code
 
 You can add more than one button to form. The arguments of ``add_button`` are the value of the button (its text) and the url where to redirect to.
+(See also the buttons argument for SQLFORM, which provides a more powerful approach)
 
 #### More about manipulation of FORMs
 As discussed in the Views chapter, a FORM is an HTML helper. Helpers can be manipulated as Python lists and as dictionaries, which enables run-time creation and modification.
@@ -453,7 +454,12 @@ col3 = {'name':A('what is this?',
 - ``comments``. If set to False, does not display the col3 comments
 - ``ignore_rw``. Normally, for a create/update form, only fields marked as writable=True are shown, and for readonly forms, only fields marked as readable=True are shown. Setting ``ignore_rw=True`` causes those constraints to be ignored, and all fields are displayed. This is mostly used in the appadmin interface to display all fields for each table, overriding what the model indicates.
 - ``formstyle``:inxx ``formstyle`` determines the style to be used when serializing the form in html. It can be "table3cols" (default), "table2cols" (one row for label and comment, and one row for input), "ul" (makes an unordered list of input fields), "divs" (represents the form using css friendly divs, for arbitrary customization). ``formstyle`` can also be a function that takes (record_id, field_label, field_widget, field_comment) as attributes and returns a TR() object.
-- ``buttons``:inxx is a list of ``INPUT``s or ``TAG.BUTTON``s (though technically could be any combination of helpers) that will be added to a DIV where the submit button would go.
+- ``buttons``:inxx ``buttons`` is a list of ``INPUT``s or ``TAG.button``s (though technically could be any combination of helpers) that will be added to a DIV where the submit button would go. 
+For example, adding a URL-based back-button (for a multi-page form) and a renamed submit button:
+``
+buttons = [TAG.button('Back',_type="button",_onClick = "parent.location='%s' " % URL(...),
+             TAG.button('Next',_type="submit")]
+``:code
 - ``separator``:inxx ``separator`` sets the string that separates form labels from form input fields.
 - Optional ``attributes`` are arguments starting with underscore that you want to pass to the ``FORM`` tag that renders the ``SQLFORM`` object. Examples are:
 ``


### PR DESCRIPTION
Fixed a display error for the documentation of the buttons argument to SQLFORM, and added a simple but useful example.
