### PR TITLE
Fixed mail.sent typo

### DIFF
--- a/sources/29-web2py-english/08.markmin
+++ b/sources/29-web2py-english/08.markmin
@@ -169,7 +169,7 @@ web2py comes with a module to help in this process:
 ``
 from gluon.contrib.sms_utils import SMSCODES, sms_email
 email = sms_email('1 (111) 111-1111','T-Mobile USA (tmail)')
-mail.sent(to=email, subject='test', message='test')
+mail.send(to=email, subject='test', message='test')
 ``:code
 
 SMSCODES is a dictionary that maps names of major phone companies to the email address postfix. The ``sms_email`` function takes a phone number (as a string) and the name of a phone company and returns the email address of the phone.

--- a/sources/30-web2py-italian/12.markmin
+++ b/sources/30-web2py-italian/12.markmin
@@ -196,7 +196,7 @@ web2py disponde di un modulo per questo processo:
 ``
 from gluon.contrib.sms_utils import SMSCODES, sms_email
 email = sms_email('1 (111) 111-1111','T-Mobile USA (tmail)')
-mail.sent(to=email,subject='test',message='test')
+mail.send(to=email,subject='test',message='test')
 ``:code
 
 SMSCODES è un dizionario che mappa i nomi delle principali compagnie telefoniche al dominio dell'email del numero di telefono. La funzione ``sms_email`` richiede un numero di telefono (come una stringa) e il nome della compagnia telefonica e restituisce l'indirizzo email del telefono.

--- a/sources/32-web2py-german/08.markmin
+++ b/sources/32-web2py-german/08.markmin
@@ -163,7 +163,7 @@ web2py comes with a module to help in this process:
 ``
 from gluon.contrib.sms_utils import SMSCODES, sms_email
 email = sms_email('1 (111) 111-1111','T-Mobile USA (tmail)')
-mail.sent(to=email, subject='test', message='test')
+mail.send(to=email, subject='test', message='test')
 ``:code
 
 SMSCODES is a dictionary that maps names of major phone companies to the email address postfix. The ``sms_email`` function takes a phone number (as a string) and the name of a phone company and returns the email address of the phone.

--- a/sources/33-web2py-japanese/08.markmin
+++ b/sources/33-web2py-japanese/08.markmin
@@ -170,7 +170,7 @@ web2pyには、この処理を支援するモジュールが付属していま�
 ``
 from gluon.contrib.sms_utils import SMSCODES, sms_email
 email = sms_email('1 (111) 111-1111','T-Mobile USA (tmail)')
-mail.sent(to=email, subject='test', message='test')
+mail.send(to=email, subject='test', message='test')
 ``:code
 
 SMSCODESは、主要な電話会社のメールアドレスの後に付加する名前のマッピング辞書です。`` sms_email`` 関数は、電話番号（文字列）と電話会社の名前を受け取り、携帯電話のメールアドレスを返します。

--- a/sources/34-web2py-italian-translation-in-progress/08.markmin
+++ b/sources/34-web2py-italian-translation-in-progress/08.markmin
@@ -163,7 +163,7 @@ web2py comes with a module to help in this process:
 ``
 from gluon.contrib.sms_utils import SMSCODES, sms_email
 email = sms_email('1 (111) 111-1111','T-Mobile USA (tmail)')
-mail.sent(to=email, subject='test', message='test')
+mail.send(to=email, subject='test', message='test')
 ``:code
 
 SMSCODES is a dictionary that maps names of major phone companies to the email address postfix. The ``sms_email`` function takes a phone number (as a string) and the name of a phone company and returns the email address of the phone.

--- a/sources/35-web2py-chinese-work-in-progress/08.markmin
+++ b/sources/35-web2py-chinese-work-in-progress/08.markmin
@@ -163,7 +163,7 @@ web2py comes with a module to help in this process:
 ``
 from gluon.contrib.sms_utils import SMSCODES, sms_email
 email = sms_email('1 (111) 111-1111','T-Mobile USA (tmail)')
-mail.sent(to=email, subject='test', message='test')
+mail.send(to=email, subject='test', message='test')
 ``:code
 
 SMSCODES is a dictionary that maps names of major phone companies to the email address postfix. The ``sms_email`` function takes a phone number (as a string) and the name of a phone company and returns the email address of the phone.

--- a/sources/36-web2py-spanish-translation-in-progress/08.markmin
+++ b/sources/36-web2py-spanish-translation-in-progress/08.markmin
@@ -180,7 +180,7 @@ web2py viene con un módulo especial para ese proceso:
 ``
 from gluon.contrib.sms_utils import SMSCODES, sms_email
 email = sms_email('1 (111) 111-1111','T-Mobile USA (tmail)')
-mail.sent(to=email, subject='prueba', message='prueba')
+mail.send(to=email, subject='prueba', message='prueba')
 ``:code
 
 SMSCODES es un diccionario que asocia los nombres de las compañías más importantes al postfijo de la dirección de correo. La función ``sms_email`` toma un número de teléfono (como cadena) y el nombre de la compañía y devuelve la dirección de correo del teléfono.

--- a/sources/37-web2py-portuguese-work-in-progress/08.markmin
+++ b/sources/37-web2py-portuguese-work-in-progress/08.markmin
@@ -169,7 +169,7 @@ web2py comes with a module to help in this process:
 ``
 from gluon.contrib.sms_utils import SMSCODES, sms_email
 email = sms_email('1 (111) 111-1111','T-Mobile USA (tmail)')
-mail.sent(to=email, subject='test', message='test')
+mail.send(to=email, subject='test', message='test')
 ``:code
 
 SMSCODES is a dictionary that maps names of major phone companies to the email address postfix. The ``sms_email`` function takes a phone number (as a string) and the name of a phone company and returns the email address of the phone.

--- a/sources/38-web2py-french-translation-in-progress/08.markmin
+++ b/sources/38-web2py-french-translation-in-progress/08.markmin
@@ -163,7 +163,7 @@ web2py comes with a module to help in this process:
 ``
 from gluon.contrib.sms_utils import SMSCODES, sms_email
 email = sms_email('1 (111) 111-1111','T-Mobile USA (tmail)')
-mail.sent(to=email, subject='test', message='test')
+mail.send(to=email, subject='test', message='test')
 ``:code
 
 SMSCODES is a dictionary that maps names of major phone companies to the email address postfix. The ``sms_email`` function takes a phone number (as a string) and the name of a phone company and returns the email address of the phone.

--- a/sources/40-web2py-czech-translation-in-progress/08.markmin
+++ b/sources/40-web2py-czech-translation-in-progress/08.markmin
@@ -163,7 +163,7 @@ web2py comes with a module to help in this process:
 ``
 from gluon.contrib.sms_utils import SMSCODES, sms_email
 email = sms_email('1 (111) 111-1111','T-Mobile USA (tmail)')
-mail.sent(to=email, subject='test', message='test')
+mail.send(to=email, subject='test', message='test')
 ``:code
 
 SMSCODES is a dictionary that maps names of major phone companies to the email address postfix. The ``sms_email`` function takes a phone number (as a string) and the name of a phone company and returns the email address of the phone.

--- a/sources/41-web2py-spanish-translation-in-progress/08.markmin
+++ b/sources/41-web2py-spanish-translation-in-progress/08.markmin
@@ -180,7 +180,7 @@ web2py viene con un módulo especial para ese proceso:
 ``
 from gluon.contrib.sms_utils import SMSCODES, sms_email
 email = sms_email('1 (111) 111-1111','T-Mobile USA (tmail)')
-mail.sent(to=email, subject='prueba', message='prueba')
+mail.send(to=email, subject='prueba', message='prueba')
 ``:code
 
 SMSCODES es un diccionario que asocia los nombres de las compañías más importantes al postfijo de la dirección de correo. La función ``sms_email`` toma un número de teléfono (como cadena) y el nombre de la compañía y devuelve la dirección de correo del teléfono.


### PR DESCRIPTION
There was a typo in the description of how to send a text message. "mail.sent" should read "mail.send". I've updated it across all languages.
