### PR TITLE
Corrected error re: auth verification settings

### DIFF
--- a/sources/29-web2py-english/09.markmin
+++ b/sources/29-web2py-english/09.markmin
@@ -183,7 +183,7 @@ auth.settings.actions_disabled.append('register')
 If you want to allow people to register and automatically log them in after registration but still want to send an email for verification so that they cannot login again after logout, unless they completed the instructions in the email, you can accomplish it as follows:
 
 ``
-auth.settings.registration_requires_approval = True
+auth.settings.registration_requires_verification = True
 auth.settings.login_after_registration = True
 ``:code
 


### PR DESCRIPTION
Corrected documentation for settings regarding "to allow people to register and automatically log them in after registration but still want to send an email for verification so that they cannot login again after logout, unless they completed the instructions in the email."
