### PR TITLE
Fixed the obsolete reference to hmac settings, better internal links.

### DIFF
--- a/sources/29-web2py-english/01.markmin
+++ b/sources/29-web2py-english/01.markmin
@@ -75,7 +75,7 @@ prevents visitors from accessing the function ``f`` unless the visitor is a memb
 
 web2py also supports components, i.e. actions which can be loaded in a view and interact with the visitor via Ajax without re-loading the entire page. This is done via a ``LOAD`` helper which allows very modular design of applications; it is discussed in chapter 3 in the context of the wiki and, in some detail, in the last chapter of this book.
 
-This 5th edition of the book describes ``web2py`` 2.4.1 and later versions.
+This 6th edition of the book describes ``web2py`` 2.4.1 and later versions.
 
 ### Principles
 
@@ -323,19 +323,20 @@ At the bottom we find the interpreter. Moving up we find the web server (rocket)
 ### About this book
 
 This book includes the following chapters, besides this introduction:
-- Chapter 2 is a minimalist introduction to Python. It assumes knowledge of both procedural and object-oriented programming concepts such as loops, conditions, function calls and classes, and covers basic Python syntax. It also covers examples of Python modules that are used throughout the book. If you already know Python, you may skip Chapter 2.
-- Chapter 3 shows how to start web2py, discusses the administrative interface, and guides the reader through various examples of increasing complexity: an application that returns a string, a counter application, an image blog, and a full blown wiki application that allows image uploads and comments, provides authentication, authorization, web services and an RSS feed. While reading this chapter, you may need to refer to Chapter 2 for general Python syntax and to the following chapters for a more detailed reference about the functions that are used.
-- Chapter 4 covers more systematically the core structure and libraries: URL mapping, request, response, sessions, caching, scheduler, cron, internationalization and general workflow.
-- Chapter 5 is a reference for the template language used to build views. It shows how to embed Python code into HTML, and demonstrates the use of helpers (objects that can generate HTML).
-- Chapter 6 covers the Database Abstraction Layer, or DAL. The syntax of the DAL is presented through a series of examples.
-- Chapter 7 covers forms, form validation and form processing. FORM is the low level helper for form building. SQLFORM is the high level form builder. In Chapter 7 we also discuss Create/Read/Update/Delete (CRUD) API.
-- Chapter 8 covers communication features as retrieving and sending emails and SMSes.
-- Chapter 9 covers authentication, authorization and the extensible Role-Based Access Control mechanism available in web2py. Mail configuration and CAPTCHA are also discussed here, since they are used for authentication. In the third edition of the book we have added extensive coverage of integration with third-party authentication mechanisms such as OpenID, OAuth, Google, Facebook, LinkedIn, etc.
-- Chapter 10 is about creating web services in web2py. We provide examples of integration with the Google Web Toolkit via Pyjamas, and with Adobe Flash via PyAMF.
-- Chapter 11 is about web2py and jQuery recipes. web2py is designed mainly for server-side programming, but it includes jQuery, since we have found it to be the best open-source JavaScript library available for effects and Ajax. In this chapter, we discuss how to effectively use jQuery with web2py.
-- Chapter 12 discusses web2py components and plugins as a way to build modular applications. We provide an example of a plugin that implements many commonly used functionality, such as charting, comments, and tagging.
-- Chapter 13 is about production deployment of web2py applications. We specifically discuss the deployment on a LAMP web server (which we consider the main deployment alternative). We discuss alterantive web servers, and configuration of the PostgreSQL database. We discuss running as a service on a Microsoft Windows environment, and deployment on some specific platforms including Google Applications Engine, Heroku, and PythonAnywhere. In this chapter, we also discuss security and scalability issues.
-- Chapter 14 contains a variety of other recipes to solve specific tasks, including upgrades, geocoding, pagination, the Twitter API, and more.
+- [[Chapter 2 ../02]] is a minimalist introduction to Python. It assumes knowledge of both procedural and object-oriented programming concepts such as loops, conditions, function calls and classes, and covers basic Python syntax. It also covers examples of Python modules that are used throughout the book. If you already know Python, you may skip Chapter 2.
+- [[Chapter 3 ../03]] shows how to start web2py, discusses the administrative interface, and guides the reader through various examples of increasing complexity: an application that returns a string, a counter application, an image blog, and a full blown wiki application that allows image uploads and comments, provides authentication, authorization, web services and an RSS feed. While reading this chapter, you may need to refer to Chapter 2 for general Python syntax and to the following chapters for a more detailed reference about the functions that are used.
+- [[Chapter 4 ../04]] covers more systematically the core structure and libraries: URL mapping, request, response, sessions, caching, scheduler, cron, internationalization and general workflow.
+- [[Chapter 5 ../05]] is a reference for the template language used to build views. It shows how to embed Python code into HTML, and demonstrates the use of helpers (objects that can generate HTML).
+- [[Chapter 6 ../06]] covers the Database Abstraction Layer, or DAL. The syntax of the DAL is presented through a series of examples.
+- [[Chapter 7 ../07]] covers forms, form validation and form processing. FORM is the low level helper for form building. SQLFORM is the high level form builder. In Chapter 7 we also discuss Create/Read/Update/Delete (CRUD) API.
+- [[Chapter 8 ../08]] covers communication features as retrieving and sending emails and SMSes.
+- [[Chapter 9 ../09]] covers authentication, authorization and the extensible Role-Based Access Control mechanism available in web2py. Mail configuration and CAPTCHA are also discussed here, since they are used for authentication. In the third edition of the book we have added extensive coverage of integration with third-party authentication mechanisms such as OpenID, OAuth, Google, Facebook, LinkedIn, etc.
+- [[Chapter 10 ../10]] is about creating web services in web2py. We provide examples of integration with the Google Web Toolkit via Pyjamas, and with Adobe Flash via PyAMF.
+- [[Chapter 11 ../11]] is about web2py and jQuery recipes. web2py is designed mainly for server-side programming, but it includes jQuery, since we have found it to be the best open-source JavaScript library available for effects and Ajax. In this chapter, we discuss how to effectively use jQuery with web2py.
+- [[Chapter 12 ../12]] discusses web2py components and plugins as a way to build modular applications. We provide an example of a plugin that implements many commonly used functionality, such as charting, comments, and tagging.
+- [[Chapter 13 ../13]] is about production deployment of web2py applications. We specifically discuss the deployment on a LAMP web server (which we consider the main deployment alternative). We discuss alterantive web servers, and configuration of the PostgreSQL database. We discuss running as a service on a Microsoft Windows environment, and deployment on some specific platforms including Google Applications Engine, Heroku, and PythonAnywhere. In this chapter, we also discuss security and scalability issues.
+- [[Chapter 14 ../14]] contains a variety of other recipes to solve specific tasks, including upgrades, geocoding, pagination, the Twitter API, and more.
+- [[Chapter 15 ../15]] has information and helping and contributing to the project, with topics such as making bug reports and contributing changes to the code.
 
 This book only covers basic web2py functionalities and the API that ships with web2py.
 This book does not cover web2py appliances (i.e. ready made applications).
@@ -344,7 +345,7 @@ You can download web2py appliances from the corresponding web site ``appliances`
 
 You can find additional topics discussed on the usergroup``usergroup``:cite. There is also AlterEgo``alterego``:cite, the old web2py blog and FAQ.
 ``MARKMIN``:inxx
-This book has been written using the markmin syntax and automatically converted to HTML, LaTeX and PDF.
+This book has been written using the [[markmin syntax ../05#markmin_syntax]] and automatically converted to HTML, LaTeX and PDF.
 
 ### Support
 
@@ -356,7 +357,9 @@ There is also a formal issue tracker system on http://code.google.com/p/web2py/i
 Any help is really appreciated. You can help other users on the user group, or by directly submitting patches on the program (at the GitHub site https://github.com/web2py/web2py). 
 Even if you find a typo on this book, or have an improvement on it, the best way to help is by patching the book itself (which is under the source folder of the repository 
 at https://github.com/mdipierro/web2py-book).
+For more information on contributing, please see [[Chapter 15 ..\15]]
 
+[[web2py_style]]
 ### Elements of style
 
 PEP8 ``style``:cite  contains good style practices when programming with Python. You will find

--- a/sources/29-web2py-english/04.markmin
+++ b/sources/29-web2py-english/04.markmin
@@ -482,6 +482,7 @@ gluon/contrib/markdown/markdown2.py
 ``
 gluon/contrib/markmin
 ``:code
+(see [[MARKMIN syntax ../05/#markmin_syntax]] for more)
 
 **fpdf** created my Mariano Reingart for generating PDF documents:
 ``
@@ -1850,7 +1851,7 @@ with
 T.M("hello world")
 ``
 
-Now the string accepts MARKMIN markup as described later in the book. You can also use the pluralization system inside MARKMIN.
+Now the string accepts MARKMIN markup as described in [[Chapter 5 ../05#markmin_syntax]]
 
 ### Cookies
 

--- a/sources/29-web2py-english/05.markmin
+++ b/sources/29-web2py-english/05.markmin
@@ -790,6 +790,7 @@ To be used for building ``META`` tags in the ``HTML`` head. For example:
 <meta name="security" content="high" />
 ``:code
 
+[[markmin_syntax]]
 #### ``MARKMIN``
 
 Implements the markmin wiki syntax. It converts the input text into output html according to the markmin rules described in the example below:
@@ -842,6 +843,13 @@ Here is a basic syntax primer:
 ``$````$\int_a^b sin(x)dx$````$``  | $$\int_a^b sin(x)dx$$
 ---------------------------------------------------
 
+##### MARKMIN links
+
+Links take this form: ``[[link display text <link>]]``
+<link> can be an anchor e.g. ``#myanchor``
+or a URI e.g. ``http://www.web2py.com``
+or a relative reference e.g. ``[[See Chapter 8 ../08]]`` or ``[[See Chapter 8 ../08#myanchor]]``
+
 Simply including a link to an image, a videos or an audio files without markup result in the corresponding image, video or audio file being included automatically (for audio and video it uses html <audio> and <video> tags).
 
 Adding a link with the ``qr:`` prefix such as
@@ -866,6 +874,7 @@ Images can also be embedded with the following syntax:
 [[image-description http://.../image.png right 200px]]
 ``
 
+##### MARKMIN lists and tables
 Unordered lists with:
 ``
 - one
@@ -889,6 +898,7 @@ and tables with:
 ----------
 ``
 
+##### extending MARKMIN 
 The MARKMIN syntax also supports blockquotes, HTML5 audio and video tags, image alignment, custom css, and it can be extended:
 
 ``

--- a/sources/29-web2py-english/09.markmin
+++ b/sources/29-web2py-english/09.markmin
@@ -744,9 +744,12 @@ Those functions do explicitly what ``enable_record_versioning`` does automatical
 they will be deprecated.
 
 
+[[mail_and_auth]]
 #### ``Mail`` and ``Auth``
 
-One can define a mailer with
+You can read more about web2py API for emails and email configuration in [[Chapter 8 ../08 ]]. Here we limit the discussion to the interaction between ``Mail`` and ``Auth``.
+
+Define a mailer with
 
 ``
 from gluon.tools import Mail
@@ -768,7 +771,6 @@ mail.settings.login = 'username:password'
 
 You need to replace the mail.settings with the proper parameters for your SMTP server. Set ``mail.settings.login = None`` if the SMTP server does not require authentication. If you don't want to use TLS, set ``mail.settings.tls = False``
 
-You can read more about web2py API for emails and email configuration in Chapter 8. Here we limit the discussion to the interaction between ``Mail`` and ``Auth``.
 
 In ``Auth``, by default, email verification is disabled.
 To enable email, append the following lines in the model where ``auth`` is defined:
@@ -1159,7 +1161,7 @@ user = auth.login_bare(username,password)
 
 ``login_bare`` returns user if the user exists and the password is valid, else it returns False. ``username`` is the email if the "auth_user" table does not have a "username" field.
 
-#### Settings and messages
+#### Auth Settings and messages
 
 Here is a list of all parameters that can be customized for **Auth**
 
@@ -1169,19 +1171,21 @@ The following must point to a ``gluon.tools.Mail`` object to allow ``auth`` to s
 auth.settings.mailer = None
 ``:code
 
+Read more about setting up mail here: [[Mail and Auth #mail_and_auth]]
+
 The following must be the name of the controller that defined the ``user`` action:
 
 ``
 auth.settings.controller = 'default'
 ``:code
 
-The following is a very important setting:
+The following was a very important setting in older web2py versions:
 
 ``
 auth.settings.hmac_key = None
 ``:code
 
-It must be set to something like "sha512:a-pass-phrase" and it will be passed to the CRYPT validator for the "password" field of the ``auth_user`` table. It will be the algorithm and a-pass-phrase used to hash the passwords.
+Where it was set to something like "sha512:a-pass-phrase" and passed to the CRYPT validator for the "password" field of the ``auth_user`` table, providing the algorithm and a-pass-phrase used to hash the passwords. However, web2py no longers needs this setting because it handles this automatically.
 
 By default, auth also requires a minimum password length of 4. This can be changed:
 ``

--- a/sources/29-web2py-english/15.markmin
+++ b/sources/29-web2py-english/15.markmin
@@ -45,6 +45,8 @@ When you ready to submit a code change, discussion will probably move to the com
  ``coding style``:inxx
 Generally, follow PEP8 coding style. http://www.python.org/dev/peps/pep-0008/ 
 
+There is specific guidance here: [[web2py style ../01#web2py_style]]
+
 ### Tips on setting up a development environment 
 Chapter 13 has some tips on using various IDEs with web2py.
 
@@ -161,7 +163,7 @@ class TestVirtualFields(unittest.TestCase):
 ``Updating book``:inxx
 
 The book is also in GitHub and the same git workflow can be used.
-The book source contains sources in various languages, under the sources directory. The content is written in markmin.
+The book source contains sources in various languages, under the sources directory. The content is written in [[markmin ../05#markmin_syntax]] .
 The book is a web2py app. You may find it convenient to make a GitHub fork of the book, and clone your local repository in the applications directory of a web2py installation. This makes it easy to see your changes rendered in a browser.
 
 ## web2pyslices.com


### PR DESCRIPTION
hmac fix. Added a few cross references throughout the book (i.e. internal links), gave a few more examples of Markmin links, changed a reference to 5th edition and added ch 15 to the introduction's summary of chapters
