### PR TITLE
Correct number of space for the example function

### DIFF
--- a/sources/29-web2py-english/07.markmin
+++ b/sources/29-web2py-english/07.markmin
@@ -554,15 +554,15 @@ There are times when you want to use ``SQLFORM`` to benefit from its form genera
 Now, edit the previous controller and add a new action:
 ``
 def display_manual_form():
-   form = SQLFORM(db.person)
-   if form.process(session=None, formname='test').accepted:
-       response.flash = 'form accepted'
-   elif form.errors:
-       response.flash = 'form has errors'
-   else:
-       response.flash = 'please fill the form'
-   # Note: no form instance is passed to the view
-   return dict()
+    form = SQLFORM(db.person)
+    if form.process(session=None, formname='test').accepted:
+        response.flash = 'form accepted'
+    elif form.errors:
+        response.flash = 'form has errors'
+    else:
+        response.flash = 'please fill the form'
+    # Note: no form instance is passed to the view
+    return dict()
 ``:code
 
 and insert the form in the associated "default/display_manual_form.html" view:


### PR DESCRIPTION
3 spaces were used instead of 4 for this example function
