### PR TITLE
Corrected a mistake (Mistmatch between source code and book)

### DIFF
--- a/sources/29-web2py-english/09.markmin
+++ b/sources/29-web2py-english/09.markmin
@@ -1052,12 +1052,12 @@ db.define_table('dog',
    Field('small_image', 'upload'),
    Field('large_image', 'upload'))
 
-db.dog.large_image.authorization = lambda record: \
+db.dog.large_image.authorize = lambda record: \
    auth.is_logged_in() and \
    auth.has_permission('read', db.dog, record.id, auth.user.id)
 ``:code
 
-The attribute ``authorization`` of upload field can be None (the default) or a function that decides whether the user is logged in and has permission to 'read' the current record. In this example, there is no restriction on downloading images linked by the "small_image" field, but we require access control on images linked by the "large_image" field.
+The attribute ``authorize`` of upload field can be None (the default) or a function that decides whether the user is logged in and has permission to 'read' the current record. In this example, there is no restriction on downloading images linked by the "small_image" field, but we require access control on images linked by the "large_image" field.
 
 
 #### Access Control and Basic Authentication


### PR DESCRIPTION
Book said that for authorization of downloads one has to set the "authorization" attribute for the corresponding field. However, looking into the source code (dal.py, line 9852), the attribute that is actually checked is called "authorize" instead.
