### PR TITLE
Updated default value of the uploadfolder

### DIFF
--- a/sources/29-web2py-english/06.markmin
+++ b/sources/29-web2py-english/06.markmin
@@ -326,7 +326,7 @@ Not all of them are relevant for every field. "length" is relevant only for fiel
 - ``default`` sets the default value for the field. The default value is used when performing an insert if a value is not explicitly specified. It is also used to pre-populate forms built from the table using SQLFORM. Note, rather than being a fixed value, the default can instead be a function (including a lambda function) that returns a value of the appropriate type for the field. In that case, the function is called once for each record inserted, even when multiple records are inserted in a single transaction.
 - ``required`` tells the DAL that no insert should be allowed on this table if a value for this field is not explicitly specified.
 - ``requires`` is a validator or a list of validators. This is not used by the DAL, but it is used by SQLFORM. The default validators for the given types are shown in the following table:
-
+- ``uploadfolder`` while the default is ``None``, most DB adapters will default to uploading files into os.path.join(request.folder, 'uploads'). MongoAdapter does not seem to be doing so at present.
 [[field_types]]
 #### Field types
 ``field types``:inxx


### PR DESCRIPTION
Per gluon/dal.py (line 9882) in Web2py 2.9.5 - The default value of the uploadfolder is None.
Updated the documentation to reflect the same.
