### PR TITLE
Updated HTML to be HTML compatible

### DIFF
--- a/sources/29-web2py-english/03.markmin
+++ b/sources/29-web2py-english/03.markmin
@@ -730,10 +730,10 @@ Edit this new file and replace its content with the following:
 ``
 {{extend 'layout.html'}}
 <h1>Image: {{=image.title}}</h1>
-<center>
+<div style="text-align:center">
 <img width="200px"
      src="{{=URL('download', args=image.file)}}" />
-</center>
+</div>
 {{if len(comments):}}
   <h2>Comments</h2><br /><p>
   {{for post in comments:}}


### PR DESCRIPTION
There was a `<center>` tag in one of the examples, for the image blog 'show' view
