### PR TITLE
Added full explanation for MENU item lists

### DIFF
--- a/sources/29-web2py-english/05.markmin
+++ b/sources/29-web2py-english/05.markmin
@@ -1236,6 +1236,13 @@ The MENU helper takes a list of lists or of tuples of the form of ``response.men
 ``:code
 
 ------
+The first item in each list/tuple is the text to be displayed for the given menu item.
+
+The second item in each list/tuple is a boolean indicating whether that particular menu item is active
+(i.e., the currently selected item). When set to True, the MENU() helper will add a "web2py-menu-active"
+class to the <li> for that item (you can change the name of that class via the "li_active" argument to MENU
+()). Another way to specify the active url is by directly passing it to MENU() via its "active_url" argument.
+
 The third item in each list/tuple can be an HTML helper (which could include nested helpers), and the ``MENU`` helper will simply render that helper rather than creating its own ``<a>`` tag.
 ------
 


### PR DESCRIPTION
I didn't find any explanation in the documentation for all three arguments in each list representing a menu item in the MENU helper, so I added it.  Credit for the explanation of the second argument goes to Anthony: http://stackoverflow.com/questions/10071468/adding-a-view-as-menu-item-using-menu-py-in-web2py
