### PR TITLE
changing typo 'lamba' to 'lambda' (line 2596 in chapter 7)

### DIFF
--- a/sources/29-web2py-english/07.markmin
+++ b/sources/29-web2py-english/07.markmin
@@ -2593,7 +2593,7 @@ In versions of web2py after 2.6, virtual fields are shown in grids like normal f
 In older web2py versions, showing virtual fields in a grid requires use of the ``links`` argument. This is still supported for more recent versions. If table db.t1 has a field called t1.vfield which is based on the values of t1.field1 and t1.field2, do this:
 
 ``grid = SQLFORM.grid(db.t1, ..., fields = [t1.field1, t1.field2,...], 
-   links = [dict(header='Virtual Field 1',body=lamba row:row.vfield),...] )
+   links = [dict(header='Virtual Field 1',body=lambda row:row.vfield),...] )
 ``:code
 
 In all cases, because t1.vfield depends on t1.field1 and t1.field2, these fields must be present in the row. In the example above, this is guaranteed by including t1.field1 and t1.field2 in the fields argument. Alternatively, showing all fields will also work. You can suppress a field from displaying by setting the readable attribute to False. 


### PR DESCRIPTION
"links = [dict(header='Virtual Field 1',body=lamba row:row.vfield),...] )" changed to "links = [dict(header='Virtual Field 1',body=lambda row:row.vfield),...] )"
