### PR TITLE
Fix syntax error - missing comma

### DIFF
--- a/sources/29-web2py-english/06.markmin
+++ b/sources/29-web2py-english/06.markmin
@@ -334,7 +334,7 @@ The signature for define_table:
 
 Tables are defined in the DAL via ``define_table``:
 ``
->>> db.define_table('person', Field('name')
+>>> db.define_table('person', Field('name'),
     id=id,
     rname=None,
     redefine=True


### PR DESCRIPTION
Missing comma in the code explaining `define_table` in Chapter 6 of the English version.
