### PR TITLE
Corrected 'Secret Agent' example

### DIFF
--- a/sources/29-web2py-english/09.markmin
+++ b/sources/29-web2py-english/09.markmin
@@ -1072,14 +1072,14 @@ Assuming the following definitions:
 >>> from gluon.tools import Auth
 >>> auth = Auth(db)
 >>> auth.define_tables()
->>> secrets = db.define_table('document', Field('body'))
+>>> secrets = db.define_table('secret_document', Field('body'))
 >>> james_bond = db.auth_user.insert(first_name='James',
                                      last_name='Bond')
 ``:code
 
 Here is an example:
 ``
->>> doc_id = db.document.insert(body = 'top secret')
+>>> doc_id = db.secret_document.insert(body = 'top secret')
 >>> agents = auth.add_group(role = 'Secret Agent')
 >>> auth.add_membership(agents, james_bond)
 >>> auth.add_permission(agents, 'read', secrets)


### PR DESCRIPTION
db.define_table('document'....

invalid table/column name "document" is a "ALL" reserved SQL/NOSQL keyword