### PR TITLE
Clarification on the use of SQLFORM.grid.field_id

### DIFF
--- a/sources/29-web2py-english/07.markmin
+++ b/sources/29-web2py-english/07.markmin
@@ -2497,7 +2497,7 @@ db.my_table.a_field.writable = False
 db.my_table.a_field.readable = False
 
 ``:code
-- ``field_id`` must be the field of the table to be used as ID, for example ``db.mytable.id``.
+- ``field_id`` must be the field of the table to be used as ID, for example ``db.mytable.id``. This is useful when the grid query is a join of several tables. Any action button on the grid(add record, view, edit, delete) will work over db.mytable. 
 - ``left`` is an optional left join expressions used to build ``...select(left=...)``.
 - ``headers`` is a dictionary that maps 'tablename.fieldname' into the corresponding header label, e.g. ``{'auth_user.email' : 'Email Address'}``
 - ``orderby`` is used as default ordering for the rows. See [[DAL chapter ../06#orderby]] (multiple fields are possible).


### PR DESCRIPTION
Text added at L 2500: "This is useful when the grid query is a join of several tables. Any action button on the grid(add record, view, edit, delete) will work over db.mytable." 

I think that the use of **file_id** requires clarification because I stumbled onto an issue when trying to make a grid with several tables joined and had no idea about how to control over which table where operating the action buttons of the grid.