### PR TITLE
IS_IN_DB(..., multiple=(low, high)) actuexclally udes high

### DIFF
--- a/sources/29-web2py-english/07.markmin
+++ b/sources/29-web2py-english/07.markmin
@@ -2452,7 +2452,7 @@ db.person.name.requires = IS_NOT_IN_DB(recent, 'person.name')
 ``IS_IN_DB(db|set, 'table.value_field', '%(representing_field)s', zero='choose one')``
 where the third and fourth arguments are optional.
 
-``multiple=`` is also possible if the field type is a list. The default is False. It can be set to True or to a tuple (min, max) to restrict the number of values selected. So ``multiple=(1, 10)`` enforces at least one and at most ten selections.
+``multiple=`` is also possible if the field type is a list. The default is False. It can be set to True or to a tuple (min, max) to restrict the number of values selected. So ``multiple=(1, 10)`` enforces at least one and at most nine selections.
 
 Other optional arguments are discussed below.
 


### PR DESCRIPTION
Found and tested with web2py 2.18.5.

UPDATED: However, the [original docs](http://web2py.com/books/default/chapter/29/07/forms-and-validators#IS_IN_DB) might actually be the intended behavior. Then we would want to [change the current IS_IN_DB(..., multiple=...) implementation](https://github.com/web2py/pydal/pull/590).