### PR TITLE
Add reminder to commit db in scheduler tasks

### DIFF
--- a/sources/29-web2py-english/04.markmin
+++ b/sources/29-web2py-english/04.markmin
@@ -2577,6 +2577,8 @@ scheduler.queue_task('mytask', ...)
 ``:code
 as explained later in this chapter in [[queue_task #queue_task]].
 
+**NOTE:** if your task code performs any database modifications, remember to ``db.commit()`` to commit your modifications.
+
 #### Task Lifecycle
 
 All tasks follow a lifecycle

--- a/sources/38-web2py-french-translation-in-progress/03.markmin
+++ b/sources/38-web2py-french-translation-in-progress/03.markmin
@@ -451,7 +451,7 @@ Comme avant, depuis la page **site** dans **admin**, créez une nouvelle applica
 [[image @///image/en1900.png center 480px]]
 
 Nous commençons par créer un modèle, une représentation des données persistente dans l'application (les images à uploader, leurs noms, et les commentaires). Premièrement, vous avez besoin de créer/éditer un fichier modèle que nous appellerons, par manque d'imagination, "db.py". Nous supposons que le code suivant remplacera tout code existant dans "db.py". Les modèles et contrôleurs doivent avoir une extension ``.py`` puisque c'est du code Python. Si l'extension n'est pas précisée, elle est ajoutée par web2py. Les vues, elles, ont une extension ``.html`` puisqu'elles contiennent principalement du code HTML.
-
+Supprimer le modèle "menu.py".
 Modifiez le fichier "db.py" en cliquant sur le bouton "modifier" correspondant :
 
 [[image @///image/en2000.png center 480px]]


### PR DESCRIPTION
This PR adds a reminder to commit any database modifications in scheduler tasks.  This issue threw me for a loop in my own code, as I hadn't realized that the scheduler does not auto-commit db modifications.

Notice: it may be preferable to have the scheduler auto-commit instead, just like regular web2py functions.  This is a change that should not break backwards compatibility.