### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Implement the changes under the proper book source.
 
 ## Syntax
 
-The book is in the markmin syntax. Images are incuded with the syntax
+The book is in the markmin syntax. Images are included with the syntax
 
     [[image @///image/key width:200px]]
 
@@ -49,7 +49,7 @@ Index entries are added with
 
 They are used to build the printable book index.
 
-You can also add internal anchors (i.e. links) that will be automatically numbered and trasformed to hyperlinks on the Web and PDF output.
+You can also add internal anchors (i.e. links) that will be automatically numbered and transformed to hyperlinks on the Web and PDF output.
 You can find all the markmin syntax reference on this page http://web2py.com/examples/static/markmin.html
 
 Once done submit  patch as a pull request on github, or email the author.

--- a/modules/hladapter.py
+++ b/modules/hladapter.py
@@ -82,7 +82,7 @@ def hladapter(txt, clsid='',
             if k.startswith('lexer_'):
                 lexer_opts[k[6:]] = kwargs[k]
             elif k == 'hl_lines' and not isinstance(kwargs[k], tuple):
-                # alllow single value (not a tuple)
+                # allow single value (not a tuple)
                 formatter_opts[k] = (kwargs[k],)
             else:
                 formatter_opts[k] = kwargs[k]

--- a/sources/38-web2py-french-translation-in-progress/03.markmin
+++ b/sources/38-web2py-french-translation-in-progress/03.markmin
@@ -451,7 +451,7 @@ Comme avant, depuis la page **site** dans **admin**, créez une nouvelle applica
 [[image @///image/en1900.png center 480px]]
 
 Nous commençons par créer un modèle, une représentation des données persistente dans l'application (les images à uploader, leurs noms, et les commentaires). Premièrement, vous avez besoin de créer/éditer un fichier modèle que nous appellerons, par manque d'imagination, "db.py". Nous supposons que le code suivant remplacera tout code existant dans "db.py". Les modèles et contrôleurs doivent avoir une extension ``.py`` puisque c'est du code Python. Si l'extension n'est pas précisée, elle est ajoutée par web2py. Les vues, elles, ont une extension ``.html`` puisqu'elles contiennent principalement du code HTML.
-
+Supprimer le modèle "menu.py".
 Modifiez le fichier "db.py" en cliquant sur le bouton "modifier" correspondant :
 
 [[image @///image/en2000.png center 480px]]

--- a/static/js/jquery.highlight.js
+++ b/static/js/jquery.highlight.js
@@ -11,7 +11,7 @@
  *  - highlight element tag and class names can be specified in options
  *
  * Usage:
- *   // wrap every occurrance of text 'lorem' in content
+ *   // wrap every occurrence of text 'lorem' in content
  *   // with <span class='highlight'> (default options)
  *   $('#content').highlight('lorem');
  *
@@ -26,7 +26,7 @@
  *   // don't ignore case during search of term 'lorem'
  *   $('#content').highlight('lorem', { caseSensitive: true });
  *
- *   // wrap every occurrance of term 'ipsum' in content
+ *   // wrap every occurrence of term 'ipsum' in content
  *   // with <em class='important'>
  *   $('#content').highlight('ipsum', { element: 'em', className: 'important' });
  *


### PR DESCRIPTION
There are small typos in:
- README.md
- modules/hladapter.py
- static/js/jquery.highlight.js

Fixes:
- Should read `transformed` rather than `trasformed`.
- Should read `occurrence` rather than `occurrance`.
- Should read `included` rather than `incuded`.
- Should read `allow` rather than `alllow`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md